### PR TITLE
Proof of equivalence between binary-ceval and step-ceval.

### DIFF
--- a/DenotationalSemantics.v
+++ b/DenotationalSemantics.v
@@ -196,3 +196,287 @@ Fixpoint ceval (c: com): state -> list state -> state -> Prop :=
   end.
 
 End Trace.
+
+Lemma ceval_while (c: com) (b: bexp):
+  forall st1 st2 st3,
+    beval b st1 ->
+    BinRel.ceval c st1 st3 ->
+    BinRel.ceval (While b Do c EndWhile) st3 st2 ->
+    BinRel.ceval (While b Do c EndWhile) st1 st2.
+Proof.
+  intros.
+  simpl.
+  simpl in H1.
+  unfold BinRel.loop_sem,
+         Relation_Operators.omega_union in H1.
+  destruct H1 as [n H1].
+  revert st1 st2 st3 H H0 H1.
+  induction n; intros.
+  + unfold BinRel.loop_sem,
+           Relation_Operators.omega_union.
+    exists (S O).
+    exists st1.
+    firstorder.
+  + simpl in H1.
+    unfold Relation_Operators.concat in H1.
+    destruct H1 as [st3' [HTest H1]].
+    unfold Relation_Operators.test_rel in HTest.
+    destruct HTest as [Hst Hb].
+    subst st3'.
+    destruct H1 as [st4 [Hc Hiter]].
+    pose proof IHn _ _ _ Hb Hc Hiter.
+Admitted.
+
+
+(* General Theorem for equivalence between two recursively defined semantics *)
+
+Definition equiv_between_recur_sem {X: Type} 
+                                   (f1: com -> state -> state -> Prop) 
+                                   (f2: com -> state -> X -> state -> Prop) : Prop :=
+  forall c st1 st2, f1 c st1 st2 <-> (exists a, f2 c st1 a st2).
+
+Theorem equiv_between_normal_time:
+  equiv_between_recur_sem BinRel.ceval StepCnt.ceval.
+Proof.
+  unfold equiv_between_recur_sem; intros.
+  revert st1 st2.
+  induction c; intros.
+  + split; intros.
+    - exists 0.
+      inversion H; subst.
+      simpl; unfold StepCnt.skip_sem.
+      tauto.
+    - destruct H; inversion H; subst.
+      unfold BinRel.ceval.
+      reflexivity.
+  + split; intros.
+    - exists 1.
+      inversion H; subst.
+      simpl; unfold StepCnt.asgn_sem.
+      firstorder.
+    - destruct H; inversion H; subst.
+      unfold BinRel.ceval.
+      firstorder.
+  + split; intros.
+    - inversion H as [st3 H0].
+      destruct H0 as [H1 H2].
+      specialize (IHc1 st1 st3).
+      destruct IHc1 as [IHc1 IHc1'].
+      specialize (IHc1 H1).
+      destruct IHc1 as [a1 IHc1].
+      specialize (IHc2 st3 st2).
+      destruct IHc2 as [IHc2 IHc2'].
+      specialize (IHc2 H2).
+      destruct IHc2 as [a2 IHc2].
+      clear IHc1' IHc2' H H1 H2.
+      exists (a1 + a2).
+      simpl; unfold StepCnt.seq_sem.
+      exists a1, a2, st3.
+      tauto.
+    - destruct H as [a H].
+      simpl in H.
+      unfold StepCnt.seq_sem in H.
+      assert (exists (t1 : Z) (st3 : state), StepCnt.ceval c1 st1 t1 st3).
+      { destruct H as [a1 [a2 [st3 [H1 ?]]]].
+        exists a1, st3.
+        exact H1. }
+      assert (exists (t2 : Z) (st3 : state), StepCnt.ceval c2 st3 t2 st2).
+      { destruct H as [a1 [a2 [st3 [? [H2 ?]]]]].
+        exists a2, st3.
+        exact H2. }
+      destruct H as [a1 [a2 [st3 [H1' [H2' Ha]]]]].
+      assert (exists (t1 : Z), StepCnt.ceval c1 st1 t1 st3) as HStep1.
+      { exists a1. exact H1'. }
+      assert (exists (t2 : Z), StepCnt.ceval c2 st3 t2 st2) as HStep2.
+      { exists a2. exact H2'. }
+      clear H1' H2' Ha H0 H1.
+      specialize (IHc1 st1 st3).
+      destruct IHc1 as [IHc1' IHc1].
+      specialize (IHc1 HStep1).
+      specialize (IHc2 st3 st2).
+      destruct IHc2 as [IHc2' IHc2].
+      specialize (IHc2 HStep2).
+      clear IHc1' IHc2' HStep1 HStep2.
+      simpl; unfold Relation_Operators.concat.
+      exists st3.
+      tauto.
+  + split; intros.
+    - simpl in H.
+      unfold BinRel.if_sem, 
+             Relation_Operators.union,
+             Relation_Operators.concat, 
+             Relation_Operators.test_rel in H.
+      destruct H; destruct H as [st1' [HTest H]].
+      * destruct HTest.
+        subst st1'.
+        specialize (IHc1 st1 st2).
+        destruct IHc1 as [IHc1 IHc1'].
+        specialize (IHc1 H).
+        destruct IHc1 as [a IHc1].
+        clear IHc1' IHc2 H.
+        exists (a + 1).
+        simpl.
+        unfold StepCnt.if_sem,
+               StepCnt.union_sem,
+               StepCnt.seq_sem,
+               StepCnt.test_sem.
+        left.
+        exists 1, a, st1.
+        firstorder.
+      * destruct HTest.
+        subst st1'.
+        specialize (IHc2 st1 st2).
+        destruct IHc2 as [IHc2 IHc2'].
+        specialize (IHc2 H).
+        destruct IHc2 as [a IHc2].
+        clear IHc2' IHc1 H.
+        exists (a + 1).
+        simpl.
+        unfold StepCnt.if_sem,
+               StepCnt.union_sem,
+               StepCnt.seq_sem,
+               StepCnt.test_sem.
+        right.
+        exists 1, a, st1.
+        firstorder.
+    - destruct H as [a H].
+      simpl in H.
+      unfold StepCnt.if_sem,
+             StepCnt.union_sem,
+             StepCnt.seq_sem,
+             StepCnt.test_sem in H.
+      destruct H.
+      * assert (exists (t1 : Z), StepCnt.ceval c1 st1 t1 st2) as HStep.
+        { destruct H as [t1 [t2 [st3 [HTest [HStep Ha]]]]].
+          destruct HTest as [Hst [Hb Ht]].
+          subst st3 t1.
+          exists t2.
+          exact HStep. }
+        specialize (IHc1 st1 st2).
+        destruct IHc1 as [IHc1' IHc1].
+        specialize (IHc1 HStep).
+        clear IHc1' IHc2 HStep.
+        simpl.
+        unfold BinRel.if_sem,
+               Relation_Operators.union,
+               Relation_Operators.concat,
+               Relation_Operators.test_rel.
+        left.
+        exists st1.
+        firstorder.
+      * assert (exists (t1 : Z), StepCnt.ceval c2 st1 t1 st2) as HStep.
+        { destruct H as [t1 [t2 [st3 [HTest [HStep Ha]]]]].
+          destruct HTest as [Hst [Hb Ht]].
+          subst st3 t1.
+          exists t2.
+          exact HStep. }
+        specialize (IHc2 st1 st2).
+        destruct IHc2 as [IHc2' IHc2].
+        specialize (IHc2 HStep).
+        clear IHc1 IHc2' HStep.
+        simpl.
+        unfold BinRel.if_sem,
+               Relation_Operators.union,
+               Relation_Operators.concat,
+               Relation_Operators.test_rel.
+        right.
+        exists st1.
+        firstorder.
+  + split; intros.
+    - simpl in H.
+      unfold BinRel.loop_sem,
+             Relation_Operators.omega_union in H.
+      destruct H as [n H].
+      revert st1 st2 H.
+      induction n; intros.
+      * destruct H as [Hst Hb].
+        exists 1.
+        simpl.
+        unfold StepCnt.loop_sem,
+               StepCnt.omega_union_sem,
+               StepCnt.iter_loop_body,
+               StepCnt.test_sem,
+               StepCnt.seq_sem.
+        exists O.
+        tauto.
+      * simpl in H.
+        unfold Relation_Operators.concat,
+               Relation_Operators.test_rel in H.
+        destruct H as [st1' [[Hst Hb] [st3 [H1 H2]]]].
+        subst st1'.
+        specialize (IHc st1 st3).
+        destruct IHc as [IHc IHc'].
+        specialize (IHc H1).
+        specialize (IHn st3 st2).
+        specialize (IHn H2).
+        destruct IHc as [ac IHc].
+        destruct IHn as [an IHn].
+        clear IHc' H1 H2 n.
+        simpl in IHn.
+        unfold StepCnt.loop_sem, StepCnt.omega_union_sem in IHn.
+        destruct IHn as [n IHn].
+        exists (ac + 1 + an).
+        simpl.
+        unfold StepCnt.loop_sem,
+               StepCnt.omega_union_sem.
+        exists (S n).
+        simpl.
+        unfold StepCnt.test_sem,
+               StepCnt.seq_sem.
+        exists 1, (ac + an), st1.
+        split; [tauto | split; [| lia] ].
+        exists ac, an, st3.
+        firstorder.
+    - simpl in H.
+      destruct H as [a H].
+      unfold StepCnt.loop_sem,
+             StepCnt.omega_union_sem in H.
+      simpl.
+      unfold BinRel.loop_sem,
+             Relation_Operators.omega_union.
+      destruct H as [n H].
+      revert IHc a st1 st2 H.
+      induction n; intros.
+      * inversion H.
+        unfold BinRel.iter_loop_body,
+               Relation_Operators.test_rel.
+        exists O.
+        tauto.
+      * destruct H as [a0 [a1 [st1' [[Hst [Hb Ha0]] [[ac [an [st3 [Hc [Hn Ha2]]]]] Ha1]]]]].
+        subst st1' a0 a1 a.
+        specialize (IHn IHc _ _ _ Hn).
+        destruct IHn as [n0 IHn].
+        assert (exists a : Z, StepCnt.ceval c st1 a st3) as Hce.
+        { exists ac. exact Hc. }
+        specialize (IHc st1 st3).
+        destruct IHc as [IHc' IHc].
+        specialize (IHc Hce).
+        exists (S n0).
+        simpl.
+        unfold Relation_Operators.concat,
+               Relation_Operators.test_rel.
+        exists st1.
+        split; [tauto |].
+        exists st3.
+        tauto.
+Qed.
+
+
+
+
+Definition Bin_Time_Equiv (X : state -> state -> Prop) 
+                          (Y : state -> Z -> state -> Prop) : Prop :=
+  forall st1 st2, X st1 st2 <-> (exists z, Y st1 z st2).
+  
+Definition Bin_Trace_Equiv (X : state -> state -> Prop) 
+                           (Y : state -> list state -> state -> Prop) : Prop :=
+  forall st1 st2, X st1 st2 <-> (exists l, Y st1 l st2).
+  
+Theorem Bin_Time_Equiv_Theorem (ceval_X: com -> state -> state -> Prop) 
+                               (ceval_Y: com -> state -> Z -> state -> Prop) :
+  forall c, Bin_Time_Equiv (ceval_X c) (ceval_Y c).
+Proof.
+  intros.
+  induction c.
+Abort.
+

--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@
 
 @Ge Qirui (https://github.com/iamgqr)
 
-@
+@Wang Kerong (https://github.com/FallCicada)


### PR DESCRIPTION
Proof of the equivalence between binary-ceval and step-ceval.
To be a reference of the general theorem.